### PR TITLE
[MRG] Implement C-API for available volume functions

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn gsw_specvol_alpha_beta(
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_rho(sa: f64, ct: f64, p: f64) -> f64 {
-    crate::volume::rho(sa, ct, p)
+    crate::rho(sa, ct, p)
 }
 
 /////////////////////////
@@ -1469,7 +1469,7 @@ mod test {
 
     #[test]
     fn test_rho_c() {
-        let result: f64 = crate::volume::rho(1., 1., 1.);
+        let result: f64 = crate::rho(1., 1., 1.);
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,11 @@
 #![no_std]
 
 /// cbindgen:ignore
+#[allow(unused)]
 mod gsw_internal_const;
 
 /// cbindgen:ignore
+#[allow(unused)]
 mod gsw_specvol_coefficients;
 
 #[cfg(feature = "capi")]
@@ -23,15 +25,13 @@ mod ffi;
 mod volume;
 
 use crate::gsw_internal_const::*;
-use crate::gsw_specvol_coefficients::*;
 pub use crate::volume::{
-    alpha, beta, specvol, specvol_alpha_beta, specvol_anom_standard, specvol_sso_0,
+    alpha, beta, rho, specvol, specvol_alpha_beta, specvol_anom_standard, specvol_sso_0,
 };
 
 #[cfg(test)]
 mod tests {
-    use super::gsw_internal_const::*;
-    use super::{alpha, beta, specvol, specvol_alpha_beta, GSW_SFAC};
+    use super::GSW_SFAC;
 
     #[test]
     // Calculated SFAC is slightly different than the prescribed SFAC in other
@@ -50,7 +50,7 @@ mod tests {
         #[cfg(feature = "compat")]
         // Values from C implementation
         assert_eq!(
-            specvol_alpha_beta(34.537484086977358, 27.793319825682374, 50.),
+            super::specvol_alpha_beta(34.537484086977358, 27.793319825682374, 50.),
             (
                 0.00097826888242888476,
                 0.00031741177706767163,

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -4,7 +4,7 @@ use crate::gsw_specvol_coefficients::*;
 pub fn alpha(sa: f64, ct: f64, p: f64) -> f64 {
     // Other implementations force negative SA to be 0. That is dangerous
     // since it can hide error by processing unrealistic inputs
-    let sa: f64 = if (sa >= 0.0) {
+    let sa: f64 = if sa >= 0.0 {
         sa
     } else if cfg!(feature = "compat") {
         0.0
@@ -39,7 +39,7 @@ pub fn alpha(sa: f64, ct: f64, p: f64) -> f64 {
 pub fn beta(sa: f64, ct: f64, p: f64) -> f64 {
     // Other implementations force negative SA to be 0. That is dangerous
     // since it can hide error by processing unrealistic inputs
-    let sa: f64 = if (sa >= 0.0) {
+    let sa: f64 = if sa >= 0.0 {
         sa
     } else if cfg!(feature = "compat") {
         0.0
@@ -89,7 +89,7 @@ pub fn beta(sa: f64, ct: f64, p: f64) -> f64 {
 pub fn specvol(sa: f64, ct: f64, p: f64) -> f64 {
     // Other implementations force negative SA to be 0. That is dangerous
     // since it can hide error by processing unrealistic inputs
-    let sa: f64 = if (sa >= 0.0) {
+    let sa: f64 = if sa >= 0.0 {
         sa
     } else if cfg!(feature = "compat") {
         0.0
@@ -193,7 +193,7 @@ pub fn specvol_anom_standard(sa: f64, ct: f64, p: f64) -> f64 {
 pub fn specvol_first_derivatives(sa: f64, ct: f64, p: f64) -> (f64, f64, f64) {
     // Other implementations force negative SA to be 0. That is dangerous
     // since it can hide error by processing unrealistic inputs
-    let sa: f64 = if (sa >= 0.0) {
+    let sa: f64 = if sa >= 0.0 {
         sa
     } else if cfg!(feature = "compat") {
         0.0
@@ -360,9 +360,7 @@ pub fn rho(sa: f64, ct: f64, p: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        alpha, beta, specvol, specvol_alpha_beta, specvol_anom_standard, specvol_sso_0, GSW_SSO,
-    };
+    use super::{alpha, beta, specvol, specvol_anom_standard, specvol_sso_0, GSW_SSO};
 
     #[test]
     // Test value from Roquet 2015, Appendix C.3


### PR DESCRIPTION
Add the already implemented functions to the C API (replacing the `unimplemented!()` blocks).

The tests are still silly (always calling with `1.` for all arguments), but good enough for checking if it works. There is an experimental PR in #7 that generates values to check functions, but it has drawbacks (more discussion on that PR).

I also fixed some of the lints (some unused imports, or extraneous parenthesis)