### PR TITLE
Avoid string-typing errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ repository = "https://github.com/castelao/GSW-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if = "1.0.0"
-libm="0.2.1"
+libm = "0.2.1"
 libc = { version = "0.2", optional = true }
 thiserror = { version = "1.0.24", optional = true }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,25 +1,11 @@
-cfg_if::cfg_if! {
-if #[cfg(feature = "std")] {
-  extern crate std;
+#[cfg(feature = "std")]
+extern crate std;
 
-  #[derive(thiserror::Error, Debug)]
-  pub enum Error {
-    #[error("Negative salinity")]
-    NegativeSalinity
-  }
-
-  impl From<&str> for Error {
-    fn from(other: &str) -> Error {
-      match other {
-        "Negative SA" => Error::NegativeSalinity,
-        _ => unimplemented!()
-      }
-    }
-  }
-
-} else {
-  pub type Error = &'static str;
-}
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug)]
+pub enum Error {
+    #[cfg_attr(feature = "std", error("Negative salinity"))]
+    NegativeSalinity,
 }
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -3,7 +3,7 @@
 
 use crate::gsw_internal_const::*;
 use crate::gsw_specvol_coefficients::*;
-use crate::Result;
+use crate::{Error, Result};
 
 pub fn alpha(sa: f64, ct: f64, p: f64) -> Result<f64> {
     // Other implementations force negative SA to be 0. That is dangerous
@@ -13,7 +13,7 @@ pub fn alpha(sa: f64, ct: f64, p: f64) -> Result<f64> {
     } else if cfg!(feature = "compat") {
         0.0
     } else {
-        return Err("Negative SA".into());
+        return Err(Error::NegativeSalinity);
     };
 
     let xs: f64 = libm::sqrt(GSW_SFAC * sa + OFFSET);
@@ -48,7 +48,7 @@ pub fn beta(sa: f64, ct: f64, p: f64) -> Result<f64> {
     } else if cfg!(feature = "compat") {
         0.0
     } else {
-        return Err("Negative SA".into());
+        return Err(Error::NegativeSalinity);
     };
 
     let xs: f64 = libm::sqrt(GSW_SFAC * sa + OFFSET);
@@ -98,7 +98,7 @@ pub fn specvol(sa: f64, ct: f64, p: f64) -> Result<f64> {
     } else if cfg!(feature = "compat") {
         0.0
     } else {
-        return Err("Negative SA".into());
+        return Err(Error::NegativeSalinity);
     };
 
     let xs: f64 = libm::sqrt(GSW_SFAC * sa + OFFSET);
@@ -209,7 +209,7 @@ pub fn specvol_first_derivatives(sa: f64, ct: f64, p: f64) -> Result<(f64, f64, 
     } else if cfg!(feature = "compat") {
         0.0
     } else {
-        return Err("Negative SA".into());
+        return Err(Error::NegativeSalinity);
     };
 
     let xs: f64 = libm::sqrt(GSW_SFAC * sa + OFFSET);
@@ -439,14 +439,10 @@ mod tests {
                 } else {
                     // It should return an error if not compat
 
-                    #[cfg(feature = "std")]
                     assert!(matches!(
                         alpha(-20.0, *ct, *p),
                         Err(crate::Error::NegativeSalinity)
                     ));
-
-                    #[cfg(not(feature = "std"))]
-                    assert!(matches!(alpha(-20.0, *ct, *p), Err("Negative SA")));
                 }
             }
         }


### PR DESCRIPTION
After #10 was merged I noticed that we can use an `Error` enum just fine on `no_std` and avoid the `&'static str`.

The catch is only using `thiserror` on the `Error` enum when the `std` feature is active (and then it will implement the [`Error` trait](https://doc.rust-lang.org/std/error/trait.Error.html)). I ended up using [`cfg_attr`](https://chrismorgan.info/blog/rust-cfg_attr/) to only activate `thiserror` when the `std` feature is active.