### PR TITLE
Moving specvol_sso_0 to gsw_internal_funcs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gsw"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Guilherme Castelão <guilherme@castelao.net>", "Luiz Irber <luiz.irber@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/gsw_internal_funcs.rs
+++ b/src/gsw_internal_funcs.rs
@@ -4,6 +4,59 @@
 
 use crate::gsw_internal_const::DB2PA;
 
+/// Specific Volume of Standard Ocean Salinity and CT=0
+///
+/// This function calculates specific volume at the Standard Ocean Salinity,
+/// SSO, and at a Conservative Temperature of zero degrees C, as a function
+/// of pressure, p, in dbar, using a streamlined version of the 75-term CT
+/// version of specific volume, that is, a streamlined version of the code
+/// "specvol(SA,CT,p)".
+///
+/// version: 3.06.12
+///
+/// If using compat (truncated constants) there is a difference of O[1e-19],
+/// which is negligible but enough to fail the validation tests.
+pub fn specvol_sso_0(p: f64) -> f64 {
+    const VXX0: f64 = if cfg!(feature = "compat") {
+        9.726_613_854_843_87e-4
+    } else {
+        9.726_613_854_843_871e-4
+    };
+
+    const VXX1: f64 = if cfg!(feature = "compat") {
+        -4.505_913_211_160_929e-5
+    } else {
+        -4.505_913_211_160_931e-5
+    };
+
+    const VXX2: f64 = if cfg!(feature = "compat") {
+        7.130_728_965_927_127e-6
+    } else {
+        7.130_728_965_927_128e-6
+    };
+
+    const VXX3: f64 = if cfg!(feature = "compat") {
+        -6.657_179_479_768_312e-7
+    } else {
+        -6.657_179_479_768_313e-7
+    };
+    const VXX4: f64 = if cfg!(feature = "compat") {
+        -2.994_054_447_232_88e-8
+    } else {
+        -2.994_054_447_232_877_6e-8
+    };
+
+    let p = crate::volume::non_dimensional_p(p);
+
+    VXX0 + p
+        * (VXX1
+            + p * (VXX2
+                + p * (VXX3
+                    + p * (VXX4
+                        + p * (crate::gsw_specvol_coefficients::V005
+                            + crate::gsw_specvol_coefficients::V006 * p)))))
+}
+
 pub(crate) fn enthalpy_sso_0(p: f64) -> f64 {
     const H006: f64 = -2.10787688100e-9;
     const H007: f64 = 2.80192913290e-10;
@@ -18,4 +71,22 @@ pub(crate) fn enthalpy_sso_0(p: f64) -> f64 {
                         + z * (-5.988_108_894_465_758e-9 + z * (H006 + H007 * z))))));
 
     dynamic_enthalpy_sso_0_p * DB2PA * 1.0e4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::specvol_sso_0;
+    use crate::gsw_internal_const::GSW_SSO;
+    use crate::volume::specvol;
+
+    /// specvol() at SSO & CT=0 should be identical to specvol_sso_0()
+    #[test]
+    fn test_specvol_vs_specvol_sso_0() {
+        let p_to_test: [f64; 5] = [0., 10., 100., 1000., 5000.];
+        for p in p_to_test.iter().cloned() {
+            let specvol = specvol(GSW_SSO, 0., p).unwrap();
+            let specvol_sso_0 = specvol_sso_0(p);
+            assert!((specvol - specvol_sso_0).abs() < f64::EPSILON);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,5 @@ pub mod volume;
 mod error;
 pub use crate::error::{Error, Result};
 
-pub use crate::volume::{
-    alpha, beta, rho, specvol, specvol_alpha_beta, specvol_anom_standard, specvol_sso_0,
-};
+pub use crate::gsw_internal_funcs::specvol_sso_0;
+pub use crate::volume::{alpha, beta, rho, specvol, specvol_alpha_beta, specvol_anom_standard};

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -53,7 +53,7 @@ fn non_dimensional_sa(sa: f64) -> Result<f64> {
 /// let p = 3812;
 /// assert!((3812.0 * 1e-4) > (3812.0 / 1e4))
 /// ```
-fn non_dimensional_p(p: f64) -> f64 {
+pub(crate) fn non_dimensional_p(p: f64) -> f64 {
     if cfg!(feature = "compat") {
         p * 1e-4
     } else {
@@ -173,53 +173,6 @@ pub fn specvol(sa: f64, ct: f64, p: f64) -> Result<f64> {
                     + z * (V004 + xs * V104 + ys * V014 + z * (V005 + z * V006))))))
 }
 
-/// Specific Volume of Standard Ocean Salinity and CT=0
-///
-/// This function calculates specific volume at the Standard Ocean Salinity,
-/// SSO, and at a Conservative Temperature of zero degrees C, as a function
-/// of pressure, p, in dbar, using a streamlined version of the 75-term CT
-/// version of specific volume, that is, a streamlined version of the code
-/// "specvol(SA,CT,p)".
-///
-/// version: 3.06.12
-///
-/// If using compat (truncated constants) there is a difference of O[1e-19],
-/// which is negligible but enough to fail the validation tests.
-pub fn specvol_sso_0(p: f64) -> f64 {
-    const VXX0: f64 = if cfg!(feature = "compat") {
-        9.726_613_854_843_87e-4
-    } else {
-        9.726_613_854_843_871e-4
-    };
-
-    const VXX1: f64 = if cfg!(feature = "compat") {
-        -4.505_913_211_160_929e-5
-    } else {
-        -4.505_913_211_160_931e-5
-    };
-
-    const VXX2: f64 = if cfg!(feature = "compat") {
-        7.130_728_965_927_127e-6
-    } else {
-        7.130_728_965_927_128e-6
-    };
-
-    const VXX3: f64 = if cfg!(feature = "compat") {
-        -6.657_179_479_768_312e-7
-    } else {
-        -6.657_179_479_768_313e-7
-    };
-    const VXX4: f64 = if cfg!(feature = "compat") {
-        -2.994_054_447_232_88e-8
-    } else {
-        -2.994_054_447_232_877_6e-8
-    };
-
-    let p = non_dimensional_p(p);
-
-    VXX0 + p * (VXX1 + p * (VXX2 + p * (VXX3 + p * (VXX4 + p * (V005 + V006 * p)))))
-}
-
 /// Specific Volume Anomaly of Standard Ocean Salinity and CT=0
 ///
 /// Specific volume anomaly with reference of SA = SSO & CT = 0 (75-term equation)
@@ -235,7 +188,7 @@ pub fn specvol_sso_0(p: f64) -> f64 {
 /// * `specvol_anom`: specific volume anomaly of seawater [m3 kg-1]
 ///
 pub fn specvol_anom_standard(sa: f64, ct: f64, p: f64) -> Result<f64> {
-    Ok(specvol(sa, ct, p)? - specvol_sso_0(p))
+    Ok(specvol(sa, ct, p)? - crate::gsw_internal_funcs::specvol_sso_0(p))
 }
 
 pub fn specvol_first_derivatives(sa: f64, ct: f64, p: f64) -> Result<(f64, f64, f64)> {
@@ -502,7 +455,7 @@ pub fn sigma4(sa: f64, ct: f64) -> Result<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{alpha, beta, specvol, specvol_anom_standard, specvol_sso_0, GSW_SSO};
+    use super::{alpha, beta, specvol, specvol_anom_standard, GSW_SSO};
 
     #[test]
     // Test value from Roquet 2015, Appendix C.3
@@ -522,17 +475,6 @@ mod tests {
                     .abs()
                     < f64::EPSILON
             );
-        }
-    }
-
-    /// specvol() at SSO & CT=0 should be identical to specvol_sso_0()
-    #[test]
-    fn test_specvol_vs_specvol_sso_0() {
-        let p_to_test: [f64; 5] = [0., 10., 100., 1000., 5000.];
-        for p in p_to_test.iter().cloned() {
-            let specvol = specvol(GSW_SSO, 0., p).unwrap();
-            let specvol_sso_0 = specvol_sso_0(p);
-            assert!((specvol - specvol_sso_0).abs() < f64::EPSILON);
         }
     }
 


### PR DESCRIPTION
Reorganizing functions following the official Toolbox card 3.06.12