### PR TITLE
Feature to control use of NaN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gsw"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Guilherme Castelão <guilherme@castelao.net>", "Luiz Irber <luiz.irber@gmail.com>"]
 edition = "2018"
 description = "TEOS-10 v3.06.12 Gibbs Seawater Oceanographic Toolbox in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ cbindgen = { version = "0.18.0", optional = true }
 default = []
 capi = ["libc", "std"]
 # Compatibility with Matlab implementation
-compat = []
+compat = ["invalidasnan"]
+# Invalid value returns Ok(f64:NAN) instead of an Error
+invalidasnan = []
 # Depth-independent gravitational acceleration. Useful for numerical models
 # Maybe rename to constg?
 nodgdz = []

--- a/src/practical_salinity.rs
+++ b/src/practical_salinity.rs
@@ -420,6 +420,26 @@ pub fn r_from_sp(sp: f64, t90: f64, p: f64) -> Result<f64> {
     Ok(r)
 }
 
+#[cfg(test)]
+mod test_r_from_sp {
+    use super::r_from_sp;
+
+    #[test]
+    // NaN input results in NaN output.
+    // Other libraries using GSW-rs might rely on this behavior to propagate
+    // and handle invalid elements.
+    fn nan() {
+        let r = r_from_sp(f64::NAN, 1.0, 1.0);
+        assert!(r.unwrap().is_nan());
+
+        let r = r_from_sp(1.0, f64::NAN, 1.0);
+        assert!(r.unwrap().is_nan());
+
+        let r = r_from_sp(1.0, 1.0, f64::NAN);
+        assert!(r.unwrap().is_nan());
+    }
+}
+
 /// Practical Salinity from a laboratory salinometer
 ///
 /// # Arguments

--- a/src/practical_salinity.rs
+++ b/src/practical_salinity.rs
@@ -216,6 +216,26 @@ pub fn sp_from_r(r: f64, t90: f64, p: f64) -> Result<f64> {
     }
 }
 
+#[cfg(test)]
+mod test_sp_from_r {
+    use super::sp_from_r;
+
+    #[test]
+    // NaN input results in NaN output.
+    // Other libraries using GSW-rs might rely on this behavior to propagate
+    // and handle invalid elements.
+    fn nan() {
+        let sp = sp_from_r(f64::NAN, 1.0, 1.0);
+        assert!(sp.unwrap().is_nan());
+
+        let sp = sp_from_r(1.0, f64::NAN, 1.0);
+        assert!(sp.unwrap().is_nan());
+
+        let sp = sp_from_r(1.0, 1.0, f64::NAN);
+        assert!(sp.unwrap().is_nan());
+    }
+}
+
 /// Conductivity ratio from Practical Salinity
 ///
 /// # Arguments

--- a/src/practical_salinity.rs
+++ b/src/practical_salinity.rs
@@ -53,6 +53,21 @@ mod test_sp_from_c {
     }
 
     #[test]
+    // NaN input results in NaN output.
+    // Other libraries using GSW-rs might rely on this behavior to propagate
+    // and handle invalid elements.
+    fn nan() {
+        let sp = sp_from_c(f64::NAN, 1.0, 1.0);
+        assert!(sp.unwrap().is_nan());
+
+        let sp = sp_from_c(1.0, f64::NAN, 1.0);
+        assert!(sp.unwrap().is_nan());
+
+        let sp = sp_from_c(1.0, 1.0, f64::NAN);
+        assert!(sp.unwrap().is_nan());
+    }
+
+    #[test]
     // MatLab returns NaN if Rt < 0
     fn negative_cndc() {
         let sp = sp_from_c(-0.1, 10.0, 100.0);
@@ -158,10 +173,13 @@ pub fn sp_from_r(r: f64, t90: f64, p: f64) -> Result<f64> {
             / (1.0 + D1 * t68 + D2 * t68 * t68 + (D3 + D4 * t68) * r);
     let rt = r / (rp * rt_lc);
 
-    // Matlab returns NaN if rt < 0
-    // C: returns GSW_INVALID_VALUE if rt < 0
+    // if rt < 0, Matlab returns NaN and C returns GSW_INVALID_VALUE
     if rt < 0.0 {
-        return Ok(f64::NAN);
+        if cfg!(feature = "invalidasnan") {
+            return Ok(f64::NAN);
+        } else {
+            return Err(Error::Undefined);
+        }
     }
 
     let rtx = libm::sqrt(rt);
@@ -183,12 +201,19 @@ pub fn sp_from_r(r: f64, t90: f64, p: f64) -> Result<f64> {
         sp = hill_ratio * sp_hill_raw;
     }
 
-    // This line ensures that SP is non-negative.
     if sp < 0.0 {
-        sp = f64::NAN;
+        // MatLab forces zero if negative.
+        if cfg!(feature = "compat") {
+            Ok(0.0)
+        // C lib returns GSW_INVALID_VALUE instead
+        } else if cfg!(feature = "invalidasnan") {
+            Ok(f64::NAN)
+        } else {
+            Err(Error::NegativeSalinity)
+        }
+    } else {
+        Ok(sp)
     }
-
-    Ok(sp)
 }
 
 /// Conductivity ratio from Practical Salinity

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -11,12 +11,16 @@ use crate::{Error, Result};
 fn non_dimensional_sa(sa: f64) -> Result<f64> {
     // Other implementations force negative SA to be 0. That is dangerous
     // since it can hide error by processing unrealistic inputs
-    let sa: f64 = if sa >= 0.0 {
-        sa
-    } else if cfg!(feature = "compat") {
-        0.0
+    let sa: f64 = if sa < 0.0 {
+        if cfg!(feature = "compat") {
+            0.0
+        } else if cfg!(feature = "invalidasnan") {
+            return Ok(f64::NAN);
+        } else {
+            return Err(Error::NegativeSalinity);
+        }
     } else {
-        return Err(Error::NegativeSalinity);
+        sa
     };
 
     Ok(libm::sqrt(GSW_SFAC * sa + OFFSET))


### PR DESCRIPTION
The feature 'compat' has been already controlling the compatibility with GSW-Matlab and GSW-C, but there are some inconsistencies. The new feature 'invalidasnan' allows to follow GSW-rs standard but return NaN instead of an error.