### PR TITLE
[MRG] C FFI updates

### DIFF
--- a/.github/workflows/gsw-python.yml
+++ b/.github/workflows/gsw-python.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest xarray
 
       - name: Install patched GSW-Python
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,10 @@ std = ["thiserror"]
 name = "gsw"
 
 [profile.dev]
-panic = "abort"
+# Avoid setting this because it requires any binary/lib linking to gsw-rs
+# to also use panic = "abort"
+# https://twitter.com/alilleybrinker/status/1391129543071526914
+#panic = "abort"
 
 [package.metadata.capi]
 # Configures the minimum required cargo-c version. Trying to run with an

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c408a087b4751c887e463e3848512c12017be25",
-        "sha256": "049l2w7sngxb354kkrvaigzkkiz5073y7s176xdvqgm4gyzp05dw",
+        "rev": "a529f0c125a78343b145a8eb2b915b0295e4f459",
+        "sha256": "0d945bdpsxaqz4d9hvsmzhcbriqwga3i0bf1ppj6lrrbqhr4pj7v",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0c408a087b4751c887e463e3848512c12017be25.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a529f0c125a78343b145a8eb2b915b0295e4f459.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5c8f3e3facc8b2d183bd18bbf9eb760ed37b5a49",
-        "sha256": "1gfw8kns1g5kyypx24w5vw42lvh1hbdsiq8vnk1yd15v5dcvdp8l",
+        "rev": "674156c4c2f46dd6a6846466cb8f9fee84c211ca",
+        "sha256": "1ypddcz6pcw6z2hw1lh51a5s6xnzjlx3v7d6ly8cmfwjh2w88z5q",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/5c8f3e3facc8b2d183bd18bbf9eb760ed37b5a49.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/674156c4c2f46dd6a6846466cb8f9fee84c211ca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -6,24 +6,31 @@ in
   with pkgs;
 
   pkgs.mkShell {
+    nativeBuildInputs = [
+      clang_13
+    ];
+
     buildInputs = [
       rustPlatform.rust.cargo
+      openssl
+      pkg-config
+
+      llvmPackages_13.libclang
+      llvmPackages_13.libcxxClang
+
       git
-      stdenv.cc.cc.lib
-      llvmPackages.libclang
-      cmake
-      rust-bindgen
+      gdb
+
       cargo-watch
       cargo-c
       cargo-asm
-      gdb
-      (python39.withPackages(ps: with ps; [ virtualenv setuptools mypy ]))
+
+      (python39.withPackages(ps: with ps; [ virtualenv setuptools mypy tox ]))
     ];
 
-    shellHook = ''
-       # workaround for https://github.com/NixOS/nixpkgs/blob/48dfc9fa97d762bce28cc8372a2dd3805d14c633/doc/languages-frameworks/python.section.md#python-setuppy-bdist_wheel-cannot-create-whl
-       export SOURCE_DATE_EPOCH=315532800 # 1980
-       export LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
-       export LIBCLANG_PATH="${llvmPackages_11.libclang.lib}/lib";
-    '';
+    BINDGEN_EXTRA_CLANG_ARGS = "-isystem ${llvmPackages_13.libclang.lib}/lib/clang/${lib.getVersion clang}/include";
+    LIBCLANG_PATH = "${llvmPackages_13.libclang.lib}/lib";
+
+    # workaround for https://github.com/NixOS/nixpkgs/blob/48dfc9fa97d762bce28cc8372a2dd3805d14c633/doc/languages-frameworks/python.section.md#python-setuppy-bdist_wheel-cannot-create-whl
+    SOURCE_DATE_EPOCH = 315532800; # 1980
   }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1504,7 +1504,7 @@ mod test {
 
     #[test]
     fn test_specvol_c() {
-        let result: f64 = crate::specvol(1., 1., 1.).unwrap();
+        let result: f64 = crate::volume::specvol(1., 1., 1.).unwrap();
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"
@@ -1521,7 +1521,7 @@ mod test {
 
     #[test]
     fn test_alpha_c() {
-        let result: f64 = crate::alpha(1., 1., 1.).unwrap();
+        let result: f64 = crate::volume::alpha(1., 1., 1.).unwrap();
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"
@@ -1538,7 +1538,7 @@ mod test {
 
     #[test]
     fn test_beta_c() {
-        let result: f64 = crate::beta(1., 1., 1.).unwrap();
+        let result: f64 = crate::volume::beta(1., 1., 1.).unwrap();
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"
@@ -1555,7 +1555,7 @@ mod test {
 
     #[test]
     fn test_specvol_sso_0_c() {
-        let result: f64 = crate::specvol_sso_0(1.);
+        let result: f64 = crate::volume::specvol_sso_0(1.);
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"
@@ -1572,7 +1572,7 @@ mod test {
 
     #[test]
     fn test_specvol_anom_standard_c() {
-        let result: f64 = crate::specvol_anom_standard(1., 1., 1.).unwrap();
+        let result: f64 = crate::volume::specvol_anom_standard(1., 1., 1.).unwrap();
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"
@@ -1589,7 +1589,7 @@ mod test {
 
     #[test]
     fn test_specvol_alpha_beta_c() {
-        let result = crate::specvol_alpha_beta(1., 1., 1.).unwrap();
+        let result = crate::volume::specvol_alpha_beta(1., 1., 1.).unwrap();
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"
@@ -1611,7 +1611,7 @@ mod test {
 
     #[test]
     fn test_rho_c() {
-        let result: f64 = crate::rho(1., 1., 1.).unwrap();
+        let result: f64 = crate::volume::rho(1., 1., 1.).unwrap();
         (assert_c! {
             #include <stdio.h>
             #include "gswteos-10.h"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,41 +15,27 @@ pub const INTERP_METHOD_PCHIP: u8 = 2;
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::volume::specvol(sa, ct, p) {
-        Ok(v) => v,
-        Err(_) => GSW_INVALID_VALUE,
-    }
+    crate::volume::specvol(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_alpha(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::volume::alpha(sa, ct, p) {
-        Ok(v) => v,
-        Err(_) => GSW_INVALID_VALUE,
-    }
+    crate::volume::alpha(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_beta(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::volume::beta(sa, ct, p) {
-        Ok(v) => v,
-        Err(_) => GSW_INVALID_VALUE,
-    }
+    crate::volume::beta(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol_sso_0(p: f64) -> f64 {
-    //crate::specvol_sso_0(p)
-    //unimplemented!()
-    f64::NAN
+    crate::volume::specvol_sso_0(p)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol_anom_standard(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::volume::specvol_anom_standard(sa, ct, p) {
-        Ok(v) => v,
-        Err(_) => GSW_INVALID_VALUE,
-    }
+    crate::volume::specvol_anom_standard(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
 }
 
 #[no_mangle]
@@ -61,22 +47,124 @@ pub unsafe extern "C" fn gsw_specvol_alpha_beta(
     alpha: *mut f64,
     beta: *mut f64,
 ) {
-    let result = match crate::volume::specvol_alpha_beta(sa, ct, p) {
-        Ok(v) => v,
-        Err(_) => (GSW_INVALID_VALUE, GSW_INVALID_VALUE, GSW_INVALID_VALUE),
-    };
-
-    *specvol = result.0;
-    *alpha = result.1;
-    *beta = result.2;
+    let (s, a, b) = crate::volume::specvol_alpha_beta(sa, ct, p).unwrap_or((
+        GSW_INVALID_VALUE,
+        GSW_INVALID_VALUE,
+        GSW_INVALID_VALUE,
+    ));
+    *specvol = s;
+    *alpha = a;
+    *beta = b;
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_rho(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::volume::rho(sa, ct, p) {
-        Ok(v) => v,
-        Err(_) => GSW_INVALID_VALUE,
-    }
+    crate::volume::rho(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_rho_alpha_beta(
+    sa: f64,
+    ct: f64,
+    p: f64,
+    rho: *mut f64,
+    alpha: *mut f64,
+    beta: *mut f64,
+) {
+    let (r, a, b) = crate::volume::rho_alpha_beta(sa, ct, p).unwrap_or((
+        GSW_INVALID_VALUE,
+        GSW_INVALID_VALUE,
+        GSW_INVALID_VALUE,
+    ));
+
+    *rho = r;
+    *alpha = a;
+    *beta = b;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sigma0(sa: f64, ct: f64) -> f64 {
+    crate::volume::sigma0(sa, ct).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sigma1(sa: f64, ct: f64) -> f64 {
+    crate::volume::sigma1(sa, ct).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sigma2(sa: f64, ct: f64) -> f64 {
+    crate::volume::sigma2(sa, ct).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sigma3(sa: f64, ct: f64) -> f64 {
+    crate::volume::sigma3(sa, ct).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sigma4(sa: f64, ct: f64) -> f64 {
+    crate::volume::sigma4(sa, ct).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sound_speed(sa: f64, ct: f64, p: f64) -> f64 {
+    crate::volume::sound_speed(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_dynamic_enthalpy(sa: f64, ct: f64, p: f64) -> f64 {
+    crate::volume::dynamic_enthalpy(sa, ct, p).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sa_from_rho(rho: f64, ct: f64, p: f64) -> f64 {
+    crate::volume::sa_from_rho(rho, ct, p).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_specvol_first_derivatives(
+    sa: f64,
+    ct: f64,
+    p: f64,
+    v_sa: *mut f64,
+    v_ct: *mut f64,
+    v_p: *mut f64,
+) {
+    let (s, c, p) = crate::volume::specvol_first_derivatives(sa, ct, p).unwrap_or((
+        GSW_INVALID_VALUE,
+        GSW_INVALID_VALUE,
+        GSW_INVALID_VALUE,
+    ));
+
+    *v_sa = s;
+    *v_ct = c;
+    *v_p = p;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sp_from_c(c: f64, t: f64, p: f64) -> f64 {
+    crate::practical_salinity::sp_from_c(c, t, p).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_c_from_sp(sp: f64, t: f64, p: f64) -> f64 {
+    crate::practical_salinity::c_from_sp(sp, t, p).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_sp_salinometer(rt: f64, t: f64) -> f64 {
+    crate::practical_salinity::sp_salinometer(rt, t).unwrap_or(GSW_INVALID_VALUE)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn gsw_z_from_p(
+    p: f64,
+    lat: f64,
+    geo_strf_dyn_height: f64,
+    sea_surface_geopotential: f64,
+) -> f64 {
+    crate::conversions::z_from_p(p, lat, geo_strf_dyn_height, sea_surface_geopotential)
 }
 
 /////////////////////////
@@ -140,12 +228,6 @@ pub unsafe extern "C" fn gsw_beta_const_t_exact(sa: f64, t: f64, p: f64) -> f64 
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_cabbeling(sa: f64, ct: f64, p: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_c_from_sp(sp: f64, t: f64, p: f64) -> f64 {
     //unimplemented!()
     f64::NAN
 }
@@ -302,12 +384,6 @@ pub unsafe extern "C" fn gsw_deltasa_from_sp(sp: f64, p: f64, lon: f64, lat: f64
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_dilution_coefficient_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_dynamic_enthalpy(sa: f64, ct: f64, p: f64) -> f64 {
     //unimplemented!()
     f64::NAN
 }
@@ -527,7 +603,7 @@ pub unsafe extern "C" fn gsw_geo_strf_dyn_height(
     dyn_height: *mut f64,
 ) -> *mut f64 {
     //unimplemented
-    0 as *mut f64
+    std::ptr::null_mut::<f64>()
 }
 
 #[no_mangle]
@@ -555,7 +631,7 @@ pub unsafe extern "C" fn gsw_geo_strf_dyn_height_pc(
     p_mid: *mut f64,
 ) -> *mut f64 {
     //unimplemented!()
-    0 as _
+    std::ptr::null_mut::<f64>()
 }
 
 #[no_mangle]
@@ -984,18 +1060,6 @@ pub unsafe extern "C" fn gsw_pt_second_derivatives(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn gsw_rho_alpha_beta(
-    sa: f64,
-    ct: f64,
-    p: f64,
-    rho: *mut f64,
-    alpha: *mut f64,
-    beta: *mut f64,
-) {
-    //unimplemented!()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn gsw_rho_first_derivatives(
     sa: f64,
     ct: f64,
@@ -1120,12 +1184,6 @@ pub unsafe extern "C" fn gsw_sa_freezing_from_t_poly(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn gsw_sa_from_rho(rho: f64, ct: f64, p: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn gsw_sa_from_sp_baltic(sp: f64, lon: f64, lat: f64) -> f64 {
     //unimplemented!()
     f64::NAN
@@ -1164,42 +1222,6 @@ pub unsafe extern "C" fn gsw_seaice_fraction_to_freeze_seawater(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn gsw_sigma0(sa: f64, ct: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_sigma1(sa: f64, ct: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_sigma2(sa: f64, ct: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_sigma3(sa: f64, ct: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_sigma4(sa: f64, ct: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_sound_speed(sa: f64, ct: f64, p: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn gsw_sound_speed_ice(t: f64, p: f64) -> f64 {
     //unimplemented!()
     f64::NAN
@@ -1209,18 +1231,6 @@ pub unsafe extern "C" fn gsw_sound_speed_ice(t: f64, p: f64) -> f64 {
 pub unsafe extern "C" fn gsw_sound_speed_t_exact(sa: f64, t: f64, p: f64) -> f64 {
     //unimplemented!()
     f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_specvol_first_derivatives(
-    sa: f64,
-    ct: f64,
-    p: f64,
-    v_sa: *mut f64,
-    v_ct: *mut f64,
-    v_p: *mut f64,
-) {
-    //unimplemented!()
 }
 
 #[no_mangle]
@@ -1273,12 +1283,6 @@ pub unsafe extern "C" fn gsw_specvol_t_exact(sa: f64, t: f64, p: f64) -> f64 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn gsw_sp_from_c(c: f64, t: f64, p: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sa_baltic(sa: f64, lon: f64, lat: f64) -> f64 {
     //unimplemented!()
     f64::NAN
@@ -1304,12 +1308,6 @@ pub unsafe extern "C" fn gsw_sp_from_sr(sr: f64) -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sstar(sstar: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    //unimplemented!()
-    f64::NAN
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_sp_salinometer(rt: f64, t: f64) -> f64 {
     //unimplemented!()
     f64::NAN
 }
@@ -1437,7 +1435,7 @@ pub unsafe extern "C" fn gsw_util_interp1q_int(
     y_i: *mut f64,
 ) -> *mut f64 {
     //unimplemented!()
-    0 as _
+    std::ptr::null_mut::<f64>()
 }
 
 #[no_mangle]
@@ -1451,7 +1449,7 @@ pub unsafe extern "C" fn gsw_util_linear_interp(
     y_i: *mut f64,
 ) -> *mut f64 {
     //unimplemented!()
-    0 as _
+    std::ptr::null_mut::<f64>()
 }
 
 #[no_mangle]
@@ -1485,17 +1483,6 @@ pub unsafe extern "C" fn gsw_util_pchip_interp(
 ) -> ::libc::c_int {
     //unimplemented!()
     0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_z_from_p(
-    p: f64,
-    lat: f64,
-    geo_strf_dyn_height: f64,
-    sea_surface_geopotential: f64,
-) -> f64 {
-    //unimplemented!()
-    f64::NAN
 }
 
 #[no_mangle]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -39,7 +39,9 @@ pub unsafe extern "C" fn gsw_beta(sa: f64, ct: f64, p: f64) -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol_sso_0(p: f64) -> f64 {
-    crate::specvol_sso_0(p)
+    //crate::specvol_sso_0(p)
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -92,72 +94,84 @@ pub unsafe extern "C" fn gsw_add_barrier(
     dlat_grid: f64,
     output_data: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_add_mean(data_in: *mut f64, data_out: *mut f64) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_adiabatic_lapse_rate_from_ct(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_adiabatic_lapse_rate_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_alpha_on_beta(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_alpha_wrt_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_alpha_wrt_t_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_beta_const_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_cabbeling(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_c_from_sp(sp: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_chem_potential_water_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_chem_potential_water_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_cp_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_cp_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -167,7 +181,7 @@ pub unsafe extern "C" fn gsw_ct_first_derivatives(
     ct_sa: *mut f64,
     ct_pt: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -179,12 +193,13 @@ pub unsafe extern "C" fn gsw_ct_first_derivatives_wrt_t_exact(
     ct_t_wrt_t: *mut f64,
     ct_p_wrt_t: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_freezing(sa: f64, p: f64, saturation_fraction: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -195,7 +210,7 @@ pub unsafe extern "C" fn gsw_ct_freezing_first_derivatives(
     ctfreezing_sa: *mut f64,
     ctfreezing_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -206,32 +221,37 @@ pub unsafe extern "C" fn gsw_ct_freezing_first_derivatives_poly(
     ctfreezing_sa: *mut f64,
     ctfreezing_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_freezing_poly(sa: f64, p: f64, saturation_fraction: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_from_enthalpy(sa: f64, h: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_from_enthalpy_exact(sa: f64, h: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_from_entropy(sa: f64, entropy: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_from_pt(sa: f64, pt: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -242,17 +262,19 @@ pub unsafe extern "C" fn gsw_ct_from_rho(
     ct: *mut f64,
     ct_multiple: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_from_t(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_ct_maxdensity(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -263,42 +285,49 @@ pub unsafe extern "C" fn gsw_ct_second_derivatives(
     ct_sa_pt: *mut f64,
     ct_pt_pt: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_deltasa_atlas(p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_deltasa_from_sp(sp: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_dilution_coefficient_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_dynamic_enthalpy(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_enthalpy_ct_exact(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_enthalpy_diff(sa: f64, ct: f64, p_shallow: f64, p_deep: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_enthalpy(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -309,7 +338,7 @@ pub unsafe extern "C" fn gsw_enthalpy_first_derivatives_ct_exact(
     h_sa: *mut f64,
     h_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -320,12 +349,13 @@ pub unsafe extern "C" fn gsw_enthalpy_first_derivatives(
     h_sa: *mut f64,
     h_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_enthalpy_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -337,7 +367,7 @@ pub unsafe extern "C" fn gsw_enthalpy_second_derivatives_ct_exact(
     h_sa_ct: *mut f64,
     h_ct_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -349,17 +379,19 @@ pub unsafe extern "C" fn gsw_enthalpy_second_derivatives(
     h_sa_ct: *mut f64,
     h_ct_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_enthalpy_sso_0(p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_enthalpy_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -369,37 +401,43 @@ pub unsafe extern "C" fn gsw_entropy_first_derivatives(
     eta_sa: *mut f64,
     eta_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_entropy_from_ct(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_entropy_from_pt(sa: f64, pt: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_entropy_from_t(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_entropy_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_entropy_part(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_entropy_part_zerop(sa: f64, pt0: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -410,12 +448,13 @@ pub unsafe extern "C" fn gsw_entropy_second_derivatives(
     eta_sa_ct: *mut f64,
     eta_ct_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_fdelta(p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -427,7 +466,7 @@ pub unsafe extern "C" fn gsw_frazil_properties(
     ct_final: *mut f64,
     w_ih_final: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -439,7 +478,7 @@ pub unsafe extern "C" fn gsw_frazil_properties_potential(
     ct_final: *mut f64,
     w_ih_final: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -451,7 +490,7 @@ pub unsafe extern "C" fn gsw_frazil_properties_potential_poly(
     ct_final: *mut f64,
     w_ih_final: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -463,7 +502,7 @@ pub unsafe extern "C" fn gsw_frazil_ratios_adiabatic(
     dsa_dp_frazil: *mut f64,
     dct_dp_frazil: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -475,7 +514,7 @@ pub unsafe extern "C" fn gsw_frazil_ratios_adiabatic_poly(
     dsa_dp_frazil: *mut f64,
     dct_dp_frazil: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -487,7 +526,8 @@ pub unsafe extern "C" fn gsw_geo_strf_dyn_height(
     n_levels: ::libc::c_int,
     dyn_height: *mut f64,
 ) -> *mut f64 {
-    unimplemented!()
+    //unimplemented
+    0 as *mut f64
 }
 
 #[no_mangle]
@@ -501,7 +541,8 @@ pub unsafe extern "C" fn gsw_geo_strf_dyn_height_1(
     max_dp_i: f64,
     interp_method: ::libc::c_int,
 ) -> ::libc::c_int {
-    unimplemented!()
+    //unimplemented!()
+    0
 }
 
 #[no_mangle]
@@ -513,7 +554,8 @@ pub unsafe extern "C" fn gsw_geo_strf_dyn_height_pc(
     geo_strf_dyn_height_pc: *mut f64,
     p_mid: *mut f64,
 ) -> *mut f64 {
-    unimplemented!()
+    //unimplemented!()
+    0 as _
 }
 
 #[no_mangle]
@@ -523,22 +565,26 @@ pub unsafe extern "C" fn gsw_gibbs_ice(
     t: f64,
     p: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_gibbs_ice_part_t(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_gibbs_ice_pt0(pt0: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_gibbs_ice_pt0_pt0(pt0: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -550,27 +596,32 @@ pub unsafe extern "C" fn gsw_gibbs(
     t: f64,
     p: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_gibbs_pt0_pt0(sa: f64, pt0: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_grav(lat: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_helmholtz_energy_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_hill_ratio_at_sp2(t: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -583,17 +634,19 @@ pub unsafe extern "C" fn gsw_ice_fraction_to_freeze_seawater(
     ct_freeze: *mut f64,
     w_ih: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_internal_energy(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_internal_energy_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -606,42 +659,49 @@ pub unsafe extern "C" fn gsw_ipv_vs_fnsquared_ratio(
     ipv_vs_fnsquared_ratio: *mut f64,
     p_mid: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_kappa_const_t_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_kappa(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_kappa_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_kappa_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_latentheat_evap_ct(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_latentheat_evap_t(sa: f64, t: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_latentheat_melting(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -655,17 +715,19 @@ pub unsafe extern "C" fn gsw_linear_interp_sa_ct(
     sa_i: *mut f64,
     ct_i: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_melting_ice_equilibrium_sa_ct_ratio(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_melting_ice_equilibrium_sa_ct_ratio_poly(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -679,12 +741,13 @@ pub unsafe extern "C" fn gsw_melting_ice_into_seawater(
     ct_final: *mut f64,
     w_ih_final: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_melting_ice_sa_ct_ratio(sa: f64, ct: f64, p: f64, t_ih: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -694,17 +757,20 @@ pub unsafe extern "C" fn gsw_melting_ice_sa_ct_ratio_poly(
     p: f64,
     t_ih: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_melting_seaice_equilibrium_sa_ct_ratio(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_melting_seaice_equilibrium_sa_ct_ratio_poly(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -718,7 +784,7 @@ pub unsafe extern "C" fn gsw_melting_seaice_into_seawater(
     sa_final: *mut f64,
     ct_final: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -729,7 +795,8 @@ pub unsafe extern "C" fn gsw_melting_seaice_sa_ct_ratio(
     sa_seaice: f64,
     t_seaice: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -740,7 +807,8 @@ pub unsafe extern "C" fn gsw_melting_seaice_sa_ct_ratio_poly(
     sa_seaice: f64,
     t_seaice: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -753,32 +821,37 @@ pub unsafe extern "C" fn gsw_nsquared(
     n2: *mut f64,
     p_mid: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_o2sol(sa: f64, ct: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_o2sol_sp_pt(sp: f64, pt: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pot_enthalpy_from_pt_ice(pt0_ice: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pot_enthalpy_from_pt_ice_poly(pt0_ice: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pot_enthalpy_ice_freezing(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -788,7 +861,7 @@ pub unsafe extern "C" fn gsw_pot_enthalpy_ice_freezing_first_derivatives(
     pot_enthalpy_ice_freezing_sa: *mut f64,
     pot_enthalpy_ice_freezing_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -798,22 +871,25 @@ pub unsafe extern "C" fn gsw_pot_enthalpy_ice_freezing_first_derivatives_poly(
     pot_enthalpy_ice_freezing_sa: *mut f64,
     pot_enthalpy_ice_freezing_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pot_enthalpy_ice_freezing_poly(sa: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pot_rho_t_exact(sa: f64, t: f64, p: f64, p_ref: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pressure_coefficient_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -822,22 +898,26 @@ pub unsafe extern "C" fn gsw_pressure_freezing_ct(
     ct: f64,
     saturation_fraction: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt0_cold_ice_poly(pot_enthalpy_ice: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt0_from_t(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt0_from_t_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -847,42 +927,49 @@ pub unsafe extern "C" fn gsw_pt_first_derivatives(
     pt_sa: *mut f64,
     pt_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_ct(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_entropy(sa: f64, entropy: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_pot_enthalpy_ice(pot_enthalpy_ice: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_pot_enthalpy_ice_poly_dh(pot_enthalpy_ice: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_pot_enthalpy_ice_poly(pot_enthalpy_ice: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_t(sa: f64, t: f64, p: f64, p_ref: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_pt_from_t_ice(t: f64, p: f64, p_ref: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -893,7 +980,7 @@ pub unsafe extern "C" fn gsw_pt_second_derivatives(
     pt_sa_ct: *mut f64,
     pt_ct_ct: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -905,7 +992,7 @@ pub unsafe extern "C" fn gsw_rho_alpha_beta(
     alpha: *mut f64,
     beta: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -917,7 +1004,7 @@ pub unsafe extern "C" fn gsw_rho_first_derivatives(
     drho_dct: *mut f64,
     drho_dp: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -928,12 +1015,13 @@ pub unsafe extern "C" fn gsw_rho_first_derivatives_wrt_enthalpy(
     rho_sa: *mut f64,
     rho_h: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_rho_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -947,7 +1035,7 @@ pub unsafe extern "C" fn gsw_rho_second_derivatives(
     rho_sa_p: *mut f64,
     rho_ct_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -959,12 +1047,13 @@ pub unsafe extern "C" fn gsw_rho_second_derivatives_wrt_enthalpy(
     rho_sa_h: *mut f64,
     rho_h_h: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_rho_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -978,12 +1067,13 @@ pub unsafe extern "C" fn gsw_rr68_interp_sa_ct(
     sa_i: *mut f64,
     ct_i: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_saar(p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -993,12 +1083,14 @@ pub unsafe extern "C" fn gsw_sa_freezing_estimate(
     ct: *mut f64,
     t: *mut f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_freezing_from_ct(ct: f64, p: f64, saturation_fraction: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1007,12 +1099,14 @@ pub unsafe extern "C" fn gsw_sa_freezing_from_ct_poly(
     p: f64,
     saturation_fraction: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_freezing_from_t(t: f64, p: f64, saturation_fraction: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1021,32 +1115,38 @@ pub unsafe extern "C" fn gsw_sa_freezing_from_t_poly(
     p: f64,
     saturation_fraction: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_from_rho(rho: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_from_sp_baltic(sp: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_from_sp(sp: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_from_sstar(sstar: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sa_p_inrange(sa: f64, p: f64) -> ::libc::c_int {
-    unimplemented!()
+    //unimplemented!()
+    0
 }
 
 #[no_mangle]
@@ -1060,47 +1160,55 @@ pub unsafe extern "C" fn gsw_seaice_fraction_to_freeze_seawater(
     ct_freeze: *mut f64,
     w_seaice: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sigma0(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sigma1(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sigma2(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sigma3(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sigma4(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sound_speed(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sound_speed_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sound_speed_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1112,7 +1220,7 @@ pub unsafe extern "C" fn gsw_specvol_first_derivatives(
     v_ct: *mut f64,
     v_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -1123,12 +1231,13 @@ pub unsafe extern "C" fn gsw_specvol_first_derivatives_wrt_enthalpy(
     v_sa: *mut f64,
     v_h: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol_ice(t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1142,7 +1251,7 @@ pub unsafe extern "C" fn gsw_specvol_second_derivatives(
     v_sa_p: *mut f64,
     v_ct_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -1154,87 +1263,103 @@ pub unsafe extern "C" fn gsw_specvol_second_derivatives_wrt_enthalpy(
     v_sa_h: *mut f64,
     v_h_h: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_c(c: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sa_baltic(sa: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sa(sa: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sk(sk: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sr(sr: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_from_sstar(sstar: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sp_salinometer(rt: f64, t: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_spiciness0(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_spiciness1(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_spiciness2(sa: f64, ct: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sr_from_sp(sp: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sstar_from_sa(sa: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_sstar_from_sp(sp: f64, p: f64, lon: f64, lat: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_t_deriv_chem_potential_water_t_exact(sa: f64, t: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_t_freezing(sa: f64, p: f64, saturation_fraction: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1245,7 +1370,7 @@ pub unsafe extern "C" fn gsw_t_freezing_first_derivatives_poly(
     tfreezing_sa: *mut f64,
     tfreezing_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -1256,27 +1381,31 @@ pub unsafe extern "C" fn gsw_t_freezing_first_derivatives(
     tfreezing_sa: *mut f64,
     tfreezing_p: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_t_freezing_poly(sa: f64, p: f64, saturation_fraction: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_t_from_ct(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_t_from_pt0_ice(pt0_ice: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_thermobaric(sa: f64, ct: f64, p: f64) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1289,12 +1418,13 @@ pub unsafe extern "C" fn gsw_turner_rsubrho(
     rsubrho: *mut f64,
     p_mid: *mut f64,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_util_indx(x: *mut f64, n: ::libc::c_int, z: f64) -> ::libc::c_int {
-    unimplemented!()
+    //unimplemented!()
+    0
 }
 
 #[no_mangle]
@@ -1306,7 +1436,8 @@ pub unsafe extern "C" fn gsw_util_interp1q_int(
     x_i: *mut f64,
     y_i: *mut f64,
 ) -> *mut f64 {
-    unimplemented!()
+    //unimplemented!()
+    0 as _
 }
 
 #[no_mangle]
@@ -1319,7 +1450,8 @@ pub unsafe extern "C" fn gsw_util_linear_interp(
     x_i: *mut f64,
     y_i: *mut f64,
 ) -> *mut f64 {
-    unimplemented!()
+    //unimplemented!()
+    0 as _
 }
 
 #[no_mangle]
@@ -1328,7 +1460,7 @@ pub unsafe extern "C" fn gsw_util_sort_real(
     nx: ::libc::c_int,
     iarray: *mut ::libc::c_int,
 ) {
-    unimplemented!()
+    //unimplemented!()
 }
 
 #[no_mangle]
@@ -1338,7 +1470,8 @@ pub unsafe extern "C" fn gsw_util_xinterp1(
     n: ::libc::c_int,
     x0: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1350,7 +1483,8 @@ pub unsafe extern "C" fn gsw_util_pchip_interp(
     yi: *mut f64,
     ni: ::libc::c_int,
 ) -> ::libc::c_int {
-    unimplemented!()
+    //unimplemented!()
+    0
 }
 
 #[no_mangle]
@@ -1360,7 +1494,8 @@ pub unsafe extern "C" fn gsw_z_from_p(
     geo_strf_dyn_height: f64,
     sea_surface_geopotential: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[no_mangle]
@@ -1370,7 +1505,8 @@ pub unsafe extern "C" fn gsw_p_from_z(
     geo_strf_dyn_height: f64,
     sea_surface_geopotential: f64,
 ) -> f64 {
-    unimplemented!()
+    //unimplemented!()
+    f64::NAN
 }
 
 #[cfg(test)]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,7 +15,7 @@ pub const INTERP_METHOD_PCHIP: u8 = 2;
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::specvol(sa, ct, p) {
+    match crate::volume::specvol(sa, ct, p) {
         Ok(v) => v,
         Err(_) => GSW_INVALID_VALUE,
     }
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn gsw_specvol(sa: f64, ct: f64, p: f64) -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_alpha(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::alpha(sa, ct, p) {
+    match crate::volume::alpha(sa, ct, p) {
         Ok(v) => v,
         Err(_) => GSW_INVALID_VALUE,
     }
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn gsw_alpha(sa: f64, ct: f64, p: f64) -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_beta(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::beta(sa, ct, p) {
+    match crate::volume::beta(sa, ct, p) {
         Ok(v) => v,
         Err(_) => GSW_INVALID_VALUE,
     }
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn gsw_specvol_sso_0(p: f64) -> f64 {
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_specvol_anom_standard(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::specvol_anom_standard(sa, ct, p) {
+    match crate::volume::specvol_anom_standard(sa, ct, p) {
         Ok(v) => v,
         Err(_) => GSW_INVALID_VALUE,
     }
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn gsw_specvol_alpha_beta(
     alpha: *mut f64,
     beta: *mut f64,
 ) {
-    let result = match crate::specvol_alpha_beta(sa, ct, p) {
+    let result = match crate::volume::specvol_alpha_beta(sa, ct, p) {
         Ok(v) => v,
         Err(_) => (GSW_INVALID_VALUE, GSW_INVALID_VALUE, GSW_INVALID_VALUE),
     };
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn gsw_specvol_alpha_beta(
 
 #[no_mangle]
 pub unsafe extern "C" fn gsw_rho(sa: f64, ct: f64, p: f64) -> f64 {
-    match crate::rho(sa, ct, p) {
+    match crate::volume::rho(sa, ct, p) {
         Ok(v) => v,
         Err(_) => GSW_INVALID_VALUE,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,3 @@ pub mod volume;
 
 mod error;
 pub use crate::error::{Error, Result};
-
-pub use crate::gsw_internal_funcs::specvol_sso_0;
-pub use crate::volume::{alpha, beta, rho, specvol, specvol_alpha_beta, specvol_anom_standard};

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -6,6 +6,8 @@ use crate::gsw_internal_funcs::non_dimensional_p;
 use crate::gsw_specvol_coefficients::*;
 use crate::{Error, Result};
 
+pub use crate::gsw_internal_funcs::specvol_sso_0;
+
 #[inline]
 /// Non-dimensional salinity
 fn non_dimensional_sa(sa: f64) -> Result<f64> {


### PR DESCRIPTION
Currently the C FFI uses `unimplemented!()` when the functionality is not implemented yet. That makes it harder for running the Python integration tests (because they panic at runtime), so I replaced most cases for returning a wrong value (`f64::NAN`) to at least be able to run all Python tests.