### PR TITLE
Wrong test value for enthalpy_diff

### DIFF
--- a/src/volume.rs
+++ b/src/volume.rs
@@ -1300,7 +1300,10 @@ mod test_enthalpy_diff {
         let h_diff = enthalpy_diff(-0.1, 10.0, 0.0, 100.0);
 
         if cfg!(feature = "compat") {
-            assert!((h_diff.unwrap() - 1000.0132803364188).abs() <= f64::EPSILON);
+            assert_eq!(
+                h_diff.unwrap(),
+                enthalpy_diff(0.0, 10.0, 0.0, 100.0).unwrap()
+            )
         } else if cfg!(feature = "invalidasnan") {
             assert!(h_diff.unwrap().is_nan());
         } else {


### PR DESCRIPTION
We were using a wrong checking value for feature compat.

Negative salinity with compat should be equal to the equivalent zero salinity case, so replace the value (wrong before) by the equivalent answer.