### PR TITLE
fix: License identifier typo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
       "orcid": "0000-0003-4371-9659"
     }
   ],
-  "license": "BSD license",
+  "license": "BSD-3-Clause",
   "contributors": [
     {
       "type": "ProjectMember",


### PR DESCRIPTION
Fixing the license identifier in .zenodo.json. The license is the same. This will only affect the automatic Zendo setup.