### PR TITLE
Fix `p_from_z` sign error, implement `gsw_p_from_z` in C FFI

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -435,8 +435,7 @@ pub fn p_from_z(
 
     let f = crate::gsw_internal_funcs::enthalpy_sso_0(p)
         + gs * (z - 0.5 * GAMMA * (z * z))
-        + geo_strf_dyn_height.unwrap_or(0.0)
-        + sea_surface_geopotental.unwrap_or(0.0);
+        - (geo_strf_dyn_height.unwrap_or(0.0) + sea_surface_geopotental.unwrap_or(0.0));
     let p_old = p;
     let p = p_old - f / df_dp;
     let p_mid = 0.5 * (p + p_old);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -348,6 +348,17 @@ pub unsafe extern "C" fn gsw_z_from_p(
     crate::conversions::z_from_p(p, lat, geo_strf_dyn_height, sea_surface_geopotential)
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn gsw_p_from_z(
+    z: f64,
+    lat: f64,
+    geo_strf_dyn_height: f64,
+    sea_surface_geopotential: f64,
+) -> f64 {
+    crate::conversions::p_from_z(z, lat, Some(geo_strf_dyn_height), Some(sea_surface_geopotential))
+        .unwrap_or(GSW_INVALID_VALUE)
+}
+
 /////////////////////////
 // To be implemented
 /////////////////////////
@@ -1530,17 +1541,6 @@ pub unsafe extern "C" fn gsw_util_pchip_interp(
 ) -> ::libc::c_int {
     //unimplemented!()
     0
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn gsw_p_from_z(
-    z: f64,
-    lat: f64,
-    geo_strf_dyn_height: f64,
-    sea_surface_geopotential: f64,
-) -> f64 {
-    //unimplemented!()
-    f64::NAN
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`test_pz_roundtrip` from GSW-Python now passes.