### PR TITLE
implement sa_from_sp_baltic

### DIFF
--- a/src/gsw_internal_funcs/mod.rs
+++ b/src/gsw_internal_funcs/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Functions not intended to be used outside this library
 
-use crate::gsw_internal_const::{DB2PA, GSW_PU, GSW_SFAC, OFFSET};
+use crate::gsw_internal_const::{DB2PA, GSW_PU, GSW_SFAC, OFFSET, GSW_SSO};
 use crate::gsw_sp_coefficients::*;
 use crate::gsw_specvol_coefficients::{V005, V006};
 use crate::{Error, Result};
@@ -1273,6 +1273,85 @@ gsw_spline_interp_SA_CT
 gsw_gibbs_ice_part_t
 gsw_gibbs_ice_pt0
 */
+
+
+// GSW_BALTIC_DATA
+const XB_LEFT: [f64; 3] = [12.6, 7.0, 26.0];
+const YB_LEFT: [f64; 3] = [50.0, 59.0, 69.0];
+const XB_RIGHT: [f64; 2] = [45.0, 26.0];
+const YB_RIGHT: [f64; 2] = [50.0, 69.0];
+
+
+fn util_indx(arr: &[f64], x: &f64) -> usize {
+    match arr.iter().position(|val| val > x) {
+        None => 0,
+        Some(idx) => {
+            if idx > 0 {
+                return idx - 1;
+            }
+            idx
+        }
+    }
+}
+
+fn util_xinterp1<const N: usize>(x: &[f64; N], y: &[f64; N], x0: &f64) -> f64{
+    let k = util_indx(x, x0);
+    let r = (x0 - x[k])/(x[k+1] - x[k]);
+    y[k] + r*(y[k+1]-y[k])
+}
+
+#[allow(dead_code)]
+fn in_baltic(lon: &f64, lat: &f64) -> bool {
+    // Basic bounding box checks
+    if !(YB_LEFT[0]..=YB_LEFT[2]).contains(lat) {
+        return false;
+    }
+    if !(XB_LEFT[1]..=XB_RIGHT[0]).contains(lon){
+        return false
+    }
+
+    let xx_left = util_xinterp1(&YB_LEFT, &XB_LEFT, lat);
+    let xx_right = util_xinterp1(&YB_RIGHT, &XB_RIGHT, lat);
+
+    if !(xx_left..=xx_right).contains(lon){
+        return false
+    }
+
+    true
+}
+
+#[allow(dead_code)]
+pub(crate) fn sa_from_sp_baltic(sp: f64, lon: f64, lat: f64) -> Result<f64> {
+    if in_baltic(&lon, &lat){
+        Ok(((GSW_SSO - 0.087)/35.0)*sp + 0.087)
+    } else {
+        Err(Error::OutOfBounds)
+    }
+}
+
+#[cfg(test)]
+mod test_sa_from_sp_baltic{
+    use super::sa_from_sp_baltic;
+
+    #[test]
+    fn check_values() {
+        let answers = [
+            (6.5683, 20.0, 59.0, 6.669945432342856),
+            (6.6719, 20.0, 59.0, 6.773776430742856),
+            (6.8108, 20.0, 59.0, 6.912986138057142),
+            (7.2629, 20.0, 59.0, 7.366094191885713),
+            (7.4825, 20.0, 59.0, 7.586183837142856),
+            (10.2796, 20.0, 59.0, 10.389520570971428),
+        ];
+        for (sp, lon, lat, ans) in answers.iter() {
+            assert!(
+                (sa_from_sp_baltic(*sp, *lon, *lat).unwrap() - *ans).abs() < f64::EPSILON,
+                "sp = {sp}, lon = {lon}, lat = {lat}, ans = {ans}"
+            );
+        } 
+    }
+}
+
 
 #[allow(dead_code)]
 pub(crate) fn gibbs_pt0_pt0(sa: f64, pt0: f64) -> Result<f64> {

--- a/src/gsw_internal_funcs/mod.rs
+++ b/src/gsw_internal_funcs/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Functions not intended to be used outside this library
 
-use crate::gsw_internal_const::{DB2PA, GSW_PU, GSW_SFAC, OFFSET, GSW_SSO};
+use crate::gsw_internal_const::{DB2PA, GSW_PU, GSW_SFAC, GSW_SSO, OFFSET};
 use crate::gsw_sp_coefficients::*;
 use crate::gsw_specvol_coefficients::{V005, V006};
 use crate::{Error, Result};
@@ -1274,13 +1274,11 @@ gsw_gibbs_ice_part_t
 gsw_gibbs_ice_pt0
 */
 
-
 // GSW_BALTIC_DATA
 const XB_LEFT: [f64; 3] = [12.6, 7.0, 26.0];
 const YB_LEFT: [f64; 3] = [50.0, 59.0, 69.0];
 const XB_RIGHT: [f64; 2] = [45.0, 26.0];
 const YB_RIGHT: [f64; 2] = [50.0, 69.0];
-
 
 fn util_indx(arr: &[f64], x: &f64) -> usize {
     match arr.iter().position(|val| val > x) {
@@ -1294,10 +1292,10 @@ fn util_indx(arr: &[f64], x: &f64) -> usize {
     }
 }
 
-fn util_xinterp1<const N: usize>(x: &[f64; N], y: &[f64; N], x0: &f64) -> f64{
+fn util_xinterp1<const N: usize>(x: &[f64; N], y: &[f64; N], x0: &f64) -> f64 {
     let k = util_indx(x, x0);
-    let r = (x0 - x[k])/(x[k+1] - x[k]);
-    y[k] + r*(y[k+1]-y[k])
+    let r = (x0 - x[k]) / (x[k + 1] - x[k]);
+    y[k] + r * (y[k + 1] - y[k])
 }
 
 #[allow(dead_code)]
@@ -1306,15 +1304,15 @@ fn in_baltic(lon: &f64, lat: &f64) -> bool {
     if !(YB_LEFT[0]..=YB_LEFT[2]).contains(lat) {
         return false;
     }
-    if !(XB_LEFT[1]..=XB_RIGHT[0]).contains(lon){
-        return false
+    if !(XB_LEFT[1]..=XB_RIGHT[0]).contains(lon) {
+        return false;
     }
 
     let xx_left = util_xinterp1(&YB_LEFT, &XB_LEFT, lat);
     let xx_right = util_xinterp1(&YB_RIGHT, &XB_RIGHT, lat);
 
-    if !(xx_left..=xx_right).contains(lon){
-        return false
+    if !(xx_left..=xx_right).contains(lon) {
+        return false;
     }
 
     true
@@ -1322,15 +1320,15 @@ fn in_baltic(lon: &f64, lat: &f64) -> bool {
 
 #[allow(dead_code)]
 pub(crate) fn sa_from_sp_baltic(sp: f64, lon: f64, lat: f64) -> Result<f64> {
-    if in_baltic(&lon, &lat){
-        Ok(((GSW_SSO - 0.087)/35.0)*sp + 0.087)
+    if in_baltic(&lon, &lat) {
+        Ok(((GSW_SSO - 0.087) / 35.0) * sp + 0.087)
     } else {
         Err(Error::OutOfBounds)
     }
 }
 
 #[cfg(test)]
-mod test_sa_from_sp_baltic{
+mod test_sa_from_sp_baltic {
     use super::sa_from_sp_baltic;
 
     #[test]
@@ -1348,10 +1346,9 @@ mod test_sa_from_sp_baltic{
                 (sa_from_sp_baltic(*sp, *lon, *lat).unwrap() - *ans).abs() < f64::EPSILON,
                 "sp = {sp}, lon = {lon}, lat = {lat}, ans = {ans}"
             );
-        } 
+        }
     }
 }
-
 
 #[allow(dead_code)]
 pub(crate) fn gibbs_pt0_pt0(sa: f64, pt0: f64) -> Result<f64> {


### PR DESCRIPTION
This is my first attempt ever at contributing to a rust project so, it's probably going to be rough. I also realize there are no doc strings yet and this potentially conflicts with #92 but wanted to "[dip my toe in](https://dictionary.cambridge.org/dictionary/english/dip-a-your-toe-in-the-water)" to use the idiom. 

Some questions/thoughts I had while doing this in no real order:
* How much is the rust version a "C" port vs a implementation in idiomatic rust? E.g. it feels like I would model the Baltic coordinate data with some sort of Point{lon, lat} struct rather than the 2 sets of 2 arrays.
* Similarly, the `in_baltic` function is not in the C version, but is duplicated in both `sa_from_sp_baltic` and `sp_from_sa_baltic`
* for future, `sa_from_sp_baltic` (and `sp_from_sa_baltic`) do not appear to be public interface for gsw, the higher level `sp_from_sa` and `sa_from_sp`call the *_baltic functions internally, check to see if they return anything valid and if not, do the SAAR lookup/conversion.
* Using the const generic in `util_xinterp1`, forces a compile time check that the two array sizes are the same which is nice, the `util_indx` cannot enforce a "2 or more" constraint until `generic_const_exprs` is stable.
* Is match allowed? I don't think I saw it used in other locations.